### PR TITLE
fix issue when resolving nested internal references

### DIFF
--- a/dollar_ref/__init__.py
+++ b/dollar_ref/__init__.py
@@ -77,7 +77,7 @@ def resolve(data, root=None, cwd: str = None,
 
     if ref.startswith('#'):
         if not external_only:
-            return resolve_internal(ref, root)
+            return resolve_internal(ref, root, cwd=cwd)
 
         return data
     elif ref.startswith(('http://', 'https://')):
@@ -122,7 +122,7 @@ def _follow_path(ref: str, data: dict) -> dict:
     return ref_data
 
 
-def resolve_internal(ref: str, root: dict) -> dict:
+def resolve_internal(ref: str, root: dict, cwd: str = None) -> dict:
     """
     Resolve an internal reference specified by `ref`.
 
@@ -132,7 +132,7 @@ def resolve_internal(ref: str, root: dict) -> dict:
 
     ref_data = _follow_path(ref, root)
 
-    return resolve(ref_data, root=root)
+    return resolve(ref_data, root=root, cwd=cwd, external_only=False)
 
 
 def resolve_file(ref: str, cwd: str, *, external_only: bool = False) -> dict:

--- a/dollar_ref/console.py
+++ b/dollar_ref/console.py
@@ -88,7 +88,9 @@ def parse_args(args):
     parser.add_argument("-v", "--verbosity",
                         action="count", default=0,
                         help='increase program output verbosity.')
-
+    parser.add_argument('-i', '--internal',
+                        help='resolve internal references',
+                        default=True, action='store_false')
     return parser.parse_args(args)
 
 
@@ -134,8 +136,7 @@ def main(custom_args: list = None):
         sys.exit(1)
 
     try:
-        resolved = resolve(data, cwd=cwd,
-                           external_only=True)
+        resolved = resolve(data, cwd=cwd, external_only=args.internal)
 
         with open(args.output_file, 'w') as out:
             if args.output_file.endswith(('yml', 'yaml')):


### PR DESCRIPTION
fix issue when resolving nested internal references - needs to pass down the current directory to get relative imports resolved

add flag `-i` to dref console command to let user choose whether to resolve external refs or not
