### PR TITLE
Fix warning emitted by yaml.load() when not defining a Loader

### DIFF
--- a/dollar_ref/__init__.py
+++ b/dollar_ref/__init__.py
@@ -200,7 +200,7 @@ def read_file(path: str) -> dict:
             log.debug(f"Decoding file '{path}' YAML.")
 
             try:
-                data = yaml.load(raw)
+                data = yaml.load(raw, Loader=yaml.FullLoader)
             except yaml.YAMLError as exc:
                 raise DecodeError(
                     f"Error decoding '{path}' file."


### PR DESCRIPTION
This PR gets rid of a warning that is emitted by `yaml.load()` when the `Loader=...` keyword argument is missing. See [this page](https://msg.pyyaml.org/load) for more details about why this argument is needed from PyYAML 5.1.